### PR TITLE
fixed hardcoded force download

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -63,6 +63,5 @@ function profilefield_file_pluginfile($course, $cm, context $context, $filearea,
         return false;
     }
 
-    // Force download
-    send_stored_file($file, 0, 0, true);
+    send_stored_file($file, 0, 0, $forcedownload);
 }


### PR DESCRIPTION
I had a need to display files from profile fields in <iframe> in custom module, but was left hanging with force download of a file. I hope that this small contribution is not going to break intended behaviors. Please leave a comment if this pull request will be declined, I'm very interested in reasoning behind hardcoded force download.